### PR TITLE
Adding a .eslintrc

### DIFF
--- a/vitalis-web/ui-app/.eslintrc
+++ b/vitalis-web/ui-app/.eslintrc
@@ -1,0 +1,60 @@
+{
+    "globals": {
+        "_": true,
+        "ch": true,
+        "App": true,
+        "Handlebars": true
+    },
+    "env": {
+        "browser": true,
+        "jquery": true
+    },
+    "rules": {
+        "block-scoped-var": ["off"],
+        "comma-dangle": ["error"],
+        "comma-style": ["error", "last"],
+        "curly": ["error"],
+        "dot-notation": ["off"],
+        "eqeqeq": ["error"],
+        "guard-for-in": ["warn"],
+        "indent": ["error"],
+        "key-spacing": ["warn"],
+        "max-len": ["error", 119],
+        "new-cap": ["error"],
+        "no-array-constructor": ["error"],
+        "no-caller": ["error"],
+        "no-eq-null": ["off"],
+        "no-eval": ["error"],
+        "no-extend-native": ["error"],
+        "no-extra-semi": ["error"],
+        "no-loop-func": ["off"],
+        "no-mixed-spaces-and-tabs": ["error"],
+        "no-new-object": ["error"],
+        "no-new-wrappers": ["error"],
+        "no-plusplus": ["error"],
+        "no-shadow": ["off"],
+        "no-spaced-func": ["error"],
+        "no-trailing-spaces": ["error"],
+        "no-undef": ["error"],
+        "no-unused-expressions": ["error"],
+        "no-unused-vars": ["error", {"vars": "all", "args": "after-used"}],
+        "no-use-before-define": ["error"],
+        "operator-linebreak": ["error", "before"],
+        "quotes": ["error", "single", "avoid-escape"],
+        "require-jsdoc": ["warn", {
+            "require": {
+                "FunctionDeclaration": true,
+                "MethodDefinition": true,
+                "ClassDeclaration": false
+            }
+        }],
+        "semi": ["error"],
+        "space-before-blocks": ["error", "always"],
+        "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
+        "space-in-parens": ["error", "never"],
+        "space-infix-ops": ["error"],
+        "strict": ["error", "never"],
+        "valid-jsdoc": ["warn", {"requireReturn": false}],
+        "vars-on-top": ["error"]
+    }
+}


### PR DESCRIPTION
Tu vida es muy simple sin un linter. Vamos a acomplejarla un poco!

Pasos luego de agregar `.eslintrc`:
- Agregar un plugin de `lint-eslint` a tu IDE favorito:
  - Atom: https://github.com/AtomLinter/linter-eslint
  - SublimeText: https://github.com/roadhump/SublimeLinter-eslint
  - IntelliJ: https://plugins.jetbrains.com/plugin/7494
- Instalar `eslint`. Probablemente haciendo: `npm install eslint@2.13.1 --global` (esta versión no depende de ES6, creo). Probar que ande ejecutando `eslint *.js` es un lugar donde tengas archivos de JS.
- Modificar `eslintrc` con tus propio estilo donde lo veas conveniente.

Pasos para ser más copado (opcional):
- Agregar [`gulp eslint`](https://www.npmjs.com/package/gulp-eslint) como tarea entrecruzada con el `gulp build`.
